### PR TITLE
[nrf noup] treewide: Adapt to NCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Zephyr Example Application
+# nRF Connect SDK Example Application
 
-This repository contains a Zephyr example application. The main purpose of this
-repository is to serve as a reference on how to structure Zephyr based
-applications. Some of the features demonstrated in this example are:
+This repository contains an nRF Connect SDK (NCS) example application. The main
+purpose of this repository is to serve as a reference on how to structure Zephyr
+based applications. Some of the features demonstrated in this example are:
 
 - Basic [Zephyr application][app_dev] skeleton
 - [Zephyr workspace applications][workspace_app]
@@ -14,12 +14,12 @@ applications. Some of the features demonstrated in this example are:
 - Example CI configuration (using Github Actions)
 - Custom [west extension][west_ext]
 
-This repository is versioned together with the [Zephyr main tree][zephyr]. This
-means that every time that Zephyr is tagged, this repository is tagged as well
+This repository is versioned together with the [NCS main tree][sdk-nrf]. This
+means that every time that NCS is tagged, this repository is tagged as well
 with the same version number, and the [manifest](west.yml) entry for `zephyr`
-will point to the corresponding Zephyr tag. For example, `example-application`
-v2.6.0 will point to Zephyr v2.6.0. Note that the `main` branch will always
-point to the development branch of Zephyr, also `main`.
+will point to the corresponding NCS tag. For example, `example-application`
+v2.6.0 will point to NCS v2.6.0. Note that the `main` branch will always
+point to the development branch of NCS, also `main`.
 
 [app_dev]: https://docs.zephyrproject.org/latest/develop/application/index.html
 [workspace_app]: https://docs.zephyrproject.org/latest/develop/application/index.html#zephyr-workspace-app
@@ -34,18 +34,18 @@ point to the development branch of Zephyr, also `main`.
 
 Before getting started, make sure you have a proper Zephyr development
 environment. You can follow the official
-[Zephyr Getting Started Guide](https://docs.zephyrproject.org/latest/getting_started/index.html).
+[NCS Getting Started Guide](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html).
 
 ### Initialization
 
 The first step is to initialize the workspace folder (``my-workspace``) where
-the ``example-application`` and all Zephyr modules will be cloned. You can do
+the ``example-application`` and all NCS modules will be cloned. You can do
 that by running:
 
 ```shell
 # initialize my-workspace for the example-application (main branch)
-west init -m https://github.com/zephyrproject-rtos/example-application --mr main my-workspace
-# update Zephyr modules
+west init -m https://github.com/nrfconnect/example-application --mr main my-workspace
+# update NCS modules
 cd my-workspace
 west update
 ```
@@ -59,7 +59,7 @@ west build -b $BOARD app
 ```
 
 where `$BOARD` is the target board. The `custom_plank` board found in this
-repository can be used. Note that Zephyr sample boards may be used if an
+repository can be used. Note that NCS sample boards may be used if an
 appropriate overlay is provided (see `app/boards`).
 
 A sample debug configuration is also provided. You can apply it by running:

--- a/west.yml
+++ b/west.yml
@@ -7,11 +7,12 @@ manifest:
     west-commands: scripts/west-commands.yml
 
   remotes:
-    - name: zephyrproject-rtos
-      url-base: https://github.com/zephyrproject-rtos
+    - name: ncs
+      url-base: https://github.com/nrfconnect
 
   projects:
-    - name: zephyr
-      remote: zephyrproject-rtos
+    - name: nrf
+      remote: ncs
+      repo-path: sdk-nrf
       revision: main
       import: true


### PR DESCRIPTION
Adapt original Zephyr repo to NCS, including the manifest and the doc.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>