### PR TITLE
NCS example application v2.5.2 manifest upate

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Nordic Semiconductor ASA
+# Copyright (c) 2021-2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 manifest:
@@ -13,5 +13,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: v2.5.1
+      revision: v2.5.2
       import: true


### PR DESCRIPTION
Manifest now follows NCS v2.5.2 release tag.