### PR TITLE
NCS example application v2.5.3 tagging

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -13,5 +13,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: v2.5.2
+      revision: v2.5.3
       import: true


### PR DESCRIPTION
Manifest now follows NCS v2.5.3 release tag.