### PR TITLE
NCS example application v2.6.1 tagging

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -13,5 +13,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: v2.6.0
+      revision: v2.6.1
       import: true


### PR DESCRIPTION
Manifest now follows NCS v2.6.1 release tag.