### PR TITLE
[nrf noup] manifest: NCS 2.6.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -13,5 +13,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: v2.6.1
+      revision: v2.6.2
       import: true


### PR DESCRIPTION
Update manifest with NCS v2.6.2 release.