### PR TITLE
[nrf noup] manifest: NCS 2.8.0

### DIFF
--- a/.github/workflows/build-using-docker.yml
+++ b/.github/workflows/build-using-docker.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-and-test-in-docker:
     runs-on: ubuntu-22.04
-    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v2.7.99
+    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v2.8.0
     defaults:
       run:
         # Bash shell is needed to set toolchain related environment variables in docker container

--- a/west.yml
+++ b/west.yml
@@ -13,5 +13,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: main
+      revision: v2.8.0
       import: true


### PR DESCRIPTION
Point to the NCS v2.8.0 release tag.
Update the docker image version.

~~DNM until release is out.~~