### PR TITLE
[nrf noup] app: add overlay for nRF54L15 DK (cpuapp)

### DIFF
--- a/app/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/app/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* This devicetree overlay file will be automatically picked by the Zephyr
+ * build system when building the sample for the nRF54l15 DK (cpuapp) board.
+ * It shows how the ncs-example-application can be built on sample boards
+ * already provided by Zephyr or NCS.
+ */
+
+/ {
+	example_sensor: example-sensor {
+		compatible = "zephyr,example-sensor";
+		input-gpios = <&gpio1 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+
+	blink_led: blink-led {
+		compatible = "blink-gpio-led";
+		led-gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>;
+		blink-period-ms = <1000>;
+	};
+};

--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -9,6 +9,7 @@ common:
   build_only: true
   integration_platforms:
     - custom_plank
+    - nrf54l15dk/nrf54l15/cpuapp
 tests:
   app.default: {}
   app.debug:


### PR DESCRIPTION
So that application can be built for that board while being functional.