### PR TITLE
Determine docker image tag based on sdk-nrf content

### DIFF
--- a/.github/workflows/build-using-docker.yml
+++ b/.github/workflows/build-using-docker.yml
@@ -5,9 +5,30 @@ on:
   push:
 
 jobs:
+  set-image-tag:
+    runs-on: ubuntu-24.04
+    outputs:
+      IMAGE_TAG: ${{ steps.set-output.outputs.IMAGE_TAG }}
+    steps:
+      - name: Checkout repository with example application
+        uses: actions/checkout@v4
+        with:
+          path: example-application
+
+      - name: Prepare west project
+        run: |
+          python3 -m pip install west
+          west init -l example-application
+          west update -o=--depth=1 -n nrf
+
+      - name: Find toolchain bundle id
+        id: set-output
+        run: echo "IMAGE_TAG=$(./nrf/scripts/print_toolchain_checksum.sh)" >> $GITHUB_OUTPUT
+
   build-and-test-in-docker:
-    runs-on: ubuntu-22.04
-    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v2.7.99
+    needs: set-image-tag
+    runs-on: ubuntu-24.04
+    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:${{ needs.set-image-tag.outputs.IMAGE_TAG }}
     defaults:
       run:
         # Bash shell is needed to set toolchain related environment variables in docker container

--- a/.github/workflows/build-using-toolchain-bundle.yml
+++ b/.github/workflows/build-using-toolchain-bundle.yml
@@ -24,10 +24,29 @@ jobs:
             chmod +x nrfutil
             ./nrfutil install toolchain-manager
 
+      - name: Find proper toolchain bundle
+        id: set-tb-id
+        run: echo "TOOLCHAIN_BUNDLE_NAME=ncs-toolchain-x86_64-linux-$(./nrf/scripts/print_toolchain_checksum.sh).tar.gz" >> $GITHUB_OUTPUT
+
+      - name: Restore toolchain bundle from cache
+        id: restore-cached-tb
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{steps.set-tb-id.outputs.TOOLCHAIN_BUNDLE_NAME}}
+          key: ${{steps.set-tb-id.outputs.TOOLCHAIN_BUNDLE_NAME}}
+
+      - name: Download toolchain bundle if not cached
+        if: steps.restore-cached-tb.outputs.cache-hit != 'true'
+        run: wget https://files.nordicsemi.com/artifactory/NCS/external/bundles/v3/${{steps.set-tb-id.outputs.TOOLCHAIN_BUNDLE_NAME}}
+
+      - name: Save toolchain bundle to cache
+        if: steps.restore-cached-tb.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{steps.set-tb-id.outputs.TOOLCHAIN_BUNDLE_NAME}}
+          key: ${{steps.set-tb-id.outputs.TOOLCHAIN_BUNDLE_NAME}}
+
       - name: Install proper toolchain bundle
-        run: |
-          TOOLCHAIN_ID=$(./nrf/scripts/print_toolchain_checksum.sh)
-          ./nrfutil toolchain-manager install --toolchain-bundle-id $TOOLCHAIN_ID
 
       - name: Build firmware
         run: |

--- a/.github/workflows/build-using-toolchain-bundle.yml
+++ b/.github/workflows/build-using-toolchain-bundle.yml
@@ -1,0 +1,40 @@
+name: Build and test app in toolchain bundle environment
+
+on:
+  pull_request:
+
+jobs:
+  build-and-test-in-toolchain-bundle:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository with example application
+        uses: actions/checkout@v4
+        with:
+          path: example-application
+
+      - name: Prepare west project
+        run: |
+          python3 -m pip install west
+          west init -l example-application
+          west update -o=--depth=1 -n
+
+      - name: Install nrfutil and toolchain manager
+        run: |
+            wget -q https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil
+            chmod +x nrfutil
+            ./nrfutil install toolchain-manager
+
+      - name: Install proper toolchain bundle
+        run: |
+          TOOLCHAIN_ID=$(./nrf/scripts/print_toolchain_checksum.sh)
+          ./nrfutil toolchain-manager install --toolchain-bundle-id $TOOLCHAIN_ID
+
+      - name: Build firmware
+        run: |
+          ./nrfutil toolchain-manager launch --chdir example-application -- west twister -T app -v --inline-logs --integration
+
+      - name: Store hex files
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-applications
+          path: example-application/twister-out/**/zephyr/zephyr.hex


### PR DESCRIPTION
Determine docker image tag based on sdk-nrf content. Add action which builds samples using toolchain bundle installed on host

Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no